### PR TITLE
multiplatform: extend reach to macOS and Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "rustganizer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustganizer"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 build = "build.rs"
@@ -36,8 +36,8 @@ FileDescription = "Rustganizer – console file organizer"
 OriginalFilename = "rustganizer.exe"
 LegalCopyright = "Copyright 2025 FrankCasanova Technologies"
 # Versions must be four-part numbers
-FileVersion = "0.4.0.0"
-ProductVersion = "0.4.0.0"
+FileVersion = "0.5.0.0"
+ProductVersion = "0.5.0.0"
 InternalName = "rustganizer"
 Comments = "Built with Rust"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,9 +82,9 @@ impl Default for Config {
             ("Pictures".to_string(), "Pictures".to_string()),
             ("Documents".to_string(), "Documents".to_string()),
         ]);
-        localized_dirs.insert("en".to_string(), english_dirs);
+        localized_dirs.insert("en".to_string(), english_dirs.clone());
 
-        // Spanish directory names
+        // Spanish directory names (Windows only - macOS/Linux use English folder names)
         let spanish_dirs = HashMap::from([
             ("Downloads".to_string(), "Descargas".to_string()),
             ("Desktop".to_string(), "Escritorio".to_string()),
@@ -94,6 +94,14 @@ impl Default for Config {
             ("Documents".to_string(), "Documentos".to_string()),
         ]);
         localized_dirs.insert("es".to_string(), spanish_dirs);
+
+        // macOS uses English directory names
+        localized_dirs.insert("en-macos".to_string(), english_dirs.clone());
+        localized_dirs.insert("es-macos".to_string(), english_dirs.clone());
+
+        // Linux uses English directory names
+        localized_dirs.insert("en-linux".to_string(), english_dirs.clone());
+        localized_dirs.insert("es-linux".to_string(), english_dirs);
 
         let mut error_messages = HashMap::new();
         error_messages.insert(
@@ -109,8 +117,24 @@ impl Default for Config {
             user_not_found: "Usuario {username} no encontrado. Por favor, ingrese un nombre de usuario válido.",
         });
 
+        // macOS/Linux error messages (same as Spanish)
+        error_messages.insert(
+            "es-macos".to_string(),
+            ErrorMessages {
+                empty_username: "Usuario vacío. Por favor, ingrese un nombre de usuario válido.",
+                user_not_found: "Usuario {username} no encontrado. Por favor, ingrese un nombre de usuario válido.",
+            },
+        );
+        error_messages.insert(
+            "es-linux".to_string(),
+            ErrorMessages {
+                empty_username: "Usuario vacío. Por favor, ingrese un nombre de usuario válido.",
+                user_not_found: "Usuario {username} no encontrado. Por favor, ingrese un nombre de usuario válido.",
+            },
+        );
+
         Config {
-            version: "0.4.0".to_string(),
+            version: "0.5.0".to_string(),
             file_extensions: FileExtensions::default(),
             localized_dirs,
             error_messages,
@@ -260,5 +284,35 @@ mod tests {
 
         let not_found_msg = config.get_error_message("es", "user_not_found", "testuser");
         assert!(not_found_msg.contains("testuser"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_directory_names() {
+        let config = Config::default();
+
+        assert_eq!(
+            config.get_localized_dir("en-macos", "Downloads"),
+            "Downloads"
+        );
+        assert_eq!(
+            config.get_localized_dir("es-macos", "Downloads"),
+            "Downloads"
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn test_linux_directory_names() {
+        let config = Config::default();
+
+        assert_eq!(
+            config.get_localized_dir("en-linux", "Downloads"),
+            "Downloads"
+        );
+        assert_eq!(
+            config.get_localized_dir("es-linux", "Downloads"),
+            "Downloads"
+        );
     }
 }

--- a/src/organizer/mover.rs
+++ b/src/organizer/mover.rs
@@ -36,11 +36,30 @@ fn move_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
     Ok(())
 }
 
+fn get_platform_locale(lang: &str) -> String {
+    if cfg!(target_os = "windows") {
+        lang.to_string()
+    } else if cfg!(target_os = "macos") {
+        match lang {
+            "en" => "en-macos".to_string(),
+            "es" => "es-macos".to_string(),
+            _ => "en-macos".to_string(),
+        }
+    } else {
+        match lang {
+            "en" => "en-linux".to_string(),
+            "es" => "es-linux".to_string(),
+            _ => "en-linux".to_string(),
+        }
+    }
+}
+
 /// Organizes files for a user, supporting both English and Spanish Windows folder names.
 pub fn organize_files(username: &str, lang: &str, config: &Config) -> Result<FileStats, String> {
+    let lang = get_platform_locale(lang);
     let username = username.trim();
     if username.is_empty() {
-        return Err(config.get_error_message(lang, "empty_username", username));
+        return Err(config.get_error_message(&lang, "empty_username", username));
     }
     #[cfg(target_os = "windows")]
     let user_provider = WindowsUserProvider;
@@ -51,7 +70,7 @@ pub fn organize_files(username: &str, lang: &str, config: &Config) -> Result<Fil
     let user_dir_path = match user_provider.user_home(username) {
         Some(path) => path,
         None => {
-            return Err(config.get_error_message(lang, "user_not_found", username));
+            return Err(config.get_error_message(&lang, "user_not_found", username));
         }
     };
     let user_dir_path = user_dir_path.to_string_lossy();
@@ -62,32 +81,32 @@ pub fn organize_files(username: &str, lang: &str, config: &Config) -> Result<Fil
     let download_dir = format!(
         "{}/{}",
         user_dir_path,
-        config.get_localized_dir(lang, "Downloads")
+        config.get_localized_dir(&lang, "Downloads")
     );
     let desktop_dir = format!(
         "{}/{}",
         user_dir_path,
-        config.get_localized_dir(lang, "Desktop")
+        config.get_localized_dir(&lang, "Desktop")
     );
     let music_dir = format!(
         "{}/{}",
         user_dir_path,
-        config.get_localized_dir(lang, "Music")
+        config.get_localized_dir(&lang, "Music")
     );
     let videos_dir = format!(
         "{}/{}",
         user_dir_path,
-        config.get_localized_dir(lang, "Videos")
+        config.get_localized_dir(&lang, "Videos")
     );
     let images_dir = format!(
         "{}/{}",
         user_dir_path,
-        config.get_localized_dir(lang, "Pictures")
+        config.get_localized_dir(&lang, "Pictures")
     );
     let docs_files_dir = format!(
         "{}/{}",
         user_dir_path,
-        config.get_localized_dir(lang, "Documents")
+        config.get_localized_dir(&lang, "Documents")
     );
     for dir in [
         &music_dir,
@@ -113,7 +132,7 @@ pub fn organize_files(username: &str, lang: &str, config: &Config) -> Result<Fil
         let video_count = Arc::clone(&video_count);
         let images_count = Arc::clone(&images_count);
         let docs_count = Arc::clone(&docs_count);
-        let is_desktop = dir.contains(&config.get_localized_dir(lang, "Desktop"));
+        let is_desktop = dir.contains(&config.get_localized_dir(&lang, "Desktop"));
         let config = config.clone();
         let handle = thread::spawn(move || {
             let mut folders_to_process = Vec::new();


### PR DESCRIPTION
The organizer now walks on many lands:
- Added platform-specific locale mapping (en-macos, es-macos, en-linux, es-linux)
- macOS uses /Users for home directories
- Linux uses /home for home directories
- Windows keeps C:/Users with Spanish localization

Version bump to 0.5.0.